### PR TITLE
Fix SDK initialization: Incorrect `Cashfree` Environment Initialization in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ npm i cashfree-pg
 
 ## Version >=5
 
-```javascript 
-import { Cashfree } from "cashfree-pg"; 
+```js 
+import { Cashfree, CFEnvironment } from "cashfree-pg";
 
-var cashfree = new Cashfree(Cashfree.SANDBOX, "<x-client-id>", "<x-client-secret>")
+const cashfree = new Cashfree(
+  CFEnvironment.SANDBOX,
+  "<x-client-id>",
+  "<x-client-secret>"
+);
 ```
 
 Generate your API keys (x-client-id , x-client-secret) from [Cashfree Merchant Dashboard](https://merchant.cashfree.com/merchants/login)

--- a/api.ts
+++ b/api.ts
@@ -18701,6 +18701,10 @@ export class Cashfree {
         }
     }
 
+    // Added for backward compatibility
+    static SANDBOX = CFEnvironment.SANDBOX;
+    static PRODUCTION = CFEnvironment.PRODUCTION;
+
     /**
      * Use this API to verify your webhook signature once you receive from Cashfree's server.
      * @summary Verify Webhook Signatures


### PR DESCRIPTION
## Fix SDK initialization: Incorrect Environment Initialization in Documentation

### Description:
 The current documentation incorrectly suggests initializing the SDK using `Cashfree.SANDBOX`, which does not exist. The correct approach is to use the `CFEnvironment` enum.

### Changes Implemented:
- [x] Updated the documentation to use `CFEnvironment.SANDBOX` instead of `Cashfree.SANDBOX`.
- [x] Add static properties to the `Cashfree` class for backward compatibility

### Fix:
#### Before:
```typescript
import { Cashfree } from "cashfree-pg";

var cashfree = new Cashfree(Cashfree.SANDBOX, "<x-client-id>", "<x-client-secret>");
```

#### After:
```typescript
import { Cashfree, CFEnvironment } from "cashfree-pg";

const cashfree = new Cashfree(CFEnvironment.SANDBOX, "<x-client-id>", "<x-client-secret>");
```


### Issue Reference:
Closes: #104

### Testing:
- This update ensures compatibility with the current SDK structure.
- Users will no longer encounter TypeScript errors due to missing static properties in the `Cashfree` class.